### PR TITLE
requirements.txt: update to s3cmd v2.0.2-custom-headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests
 click
 pyyaml
-https://github.com/leondutoit/s3cmd/archive/v20180312.tar.gz
+https://github.com/unioslo/s3cmd/archive/v2.0.2-custom-headers.tar.gz
 progress
 humanfriendly


### PR DESCRIPTION
This will make tsd-s3cmd work for Python 3 users.