### PR TITLE
Simple Windows compatibility fix

### DIFF
--- a/tsdapiclient/sync.py
+++ b/tsdapiclient/sync.py
@@ -313,6 +313,8 @@ class GenericDirectoryTransporter(object):
         integrity_reference = None
         debug_step('finding local resources to transfer')
         for directory, subdirectory, files in os.walk(path):
+            if sys.platform == 'win32':
+                directory = directory.replace("\\", "/")
             folder = directory.replace(f'{path}/', '')
             ignore_prefix = False
             for prefix in self.ignore_prefixes:

--- a/tsdapiclient/tools.py
+++ b/tsdapiclient/tools.py
@@ -77,10 +77,7 @@ def _check_present(_input, name):
 
 
 def user_agent(name='tsd-api-client'):
-    try:
-        user = os.environ.get('USER')
-    except (Exception, OSError) as e:
-        user = 'not-found'
+    user = os.environ.get('USER', default='not-found')
     hu = hashlib.md5(user.encode('utf-8')).hexdigest()
     return '{0}-{1}-{2}'.format(name, __version__, hu)
 


### PR DESCRIPTION
Tested:
* Single file upload
* Single file download
* Folder upload
* Folder download
* Download listing

There are some output formatting issues when not running in a unix-y terminal but not important for usability.