### PR TITLE
Faster sync, more robust uploads

### DIFF
--- a/tsdapiclient/fileapi.py
+++ b/tsdapiclient/fileapi.py
@@ -203,7 +203,8 @@ def import_list(
     session=requests,
     directory=None,
     page=None,
-    group=None
+    group=None,
+    per_page=None,
 ):
     """
     Get the list of files in the import direcctory, for a given group.
@@ -226,7 +227,7 @@ def import_list(
     """
     resource = f'/{directory}' if directory else ''
     endpoint=f"stream/{group}{resource}"
-    url = f'{file_api_url(env, pnum, backend, endpoint=endpoint , page=page)}'
+    url = f'{file_api_url(env, pnum, backend, endpoint=endpoint , page=page, per_page=per_page)}'
     headers = {'Authorization': 'Bearer {0}'.format(token)}
     debug_step(f'listing resources at {url}')
     resp = session.get(url, headers=headers)
@@ -246,9 +247,10 @@ def survey_list(
     directory=None,
     page=None,
     group=None,
+    per_page=None,
 ):
     endpoint=f"{directory}/attachments"
-    url = f'{file_api_url(env, pnum, backend, endpoint=endpoint, page=page)}'
+    url = f'{file_api_url(env, pnum, backend, endpoint=endpoint, page=page, per_page=per_page)}'
     headers = {'Authorization': 'Bearer {0}'.format(token)}
     debug_step(f'listing resources at {url}')
     resp = session.get(url, headers=headers)
@@ -303,7 +305,8 @@ def export_list(
     session=requests,
     directory=None,
     page=None,
-    group=None
+    group=None,
+    per_page=None,
 ):
     """
     Get the list of files available for export.
@@ -326,7 +329,7 @@ def export_list(
     """
     resource = f'/{directory}' if directory else ''
     endpoint = f'export{resource}'
-    url = f'{file_api_url(env, pnum, backend, endpoint=endpoint, page=page)}'
+    url = f'{file_api_url(env, pnum, backend, endpoint=endpoint, page=page, per_page=per_page)}'
     headers = {'Authorization': 'Bearer {0}'.format(token)}
     debug_step(f'listing resources at {url}')
     resp = session.get(url, headers=headers)

--- a/tsdapiclient/sync.py
+++ b/tsdapiclient/sync.py
@@ -424,6 +424,9 @@ class GenericDirectoryTransporter(object):
         size of the $CHUNK_THRESHOLD.
 
         """
+        if not os.path.lexists(resource):
+            print(f'WARNING: could not find {resource} on local disk')
+            return resource
         if os.stat(resource).st_size > CHUNK_THRESHOLD:
             resp = initiate_resumable(
                 self.env, self.pnum, resource, self.token, chunksize=CHUNK_SIZE,

--- a/tsdapiclient/sync.py
+++ b/tsdapiclient/sync.py
@@ -373,7 +373,8 @@ class GenericDirectoryTransporter(object):
                 directory=path,
                 page=next_page,
                 group=self.group,
-                backend=list_funcs[self.remote_key]['backend']
+                backend=list_funcs[self.remote_key]['backend'],
+                per_page=10000, # for better sync performance
             )
             found = out.get('files')
             next_page = out.get('page')

--- a/tsdapiclient/tools.py
+++ b/tsdapiclient/tools.py
@@ -50,16 +50,29 @@ def auth_api_url(env, pnum, auth_method):
         raise e
 
 
-def file_api_url(env, pnum, service, endpoint='', formid='', page=None):
+def file_api_url(
+    env,
+    pnum,
+    service,
+    endpoint='',
+    formid='',
+    page=None,
+    per_page=None,
+):
     try:
         host = HOSTS.get(env)
         if page:
-            return f'https://{host}{page}'
+            url = f'https://{host}{page}'
+            if per_page:
+                url += f'&per_page={per_page}'
+            return url
         if formid:
             endpoint = f'{formid}/{endpoint}'
         url = f'https://{host}/{API_VERSION}/{pnum}/{service}/{endpoint}'
         if url.endswith('/'):
             url = url[:-1]
+        if per_page:
+            url += f'?per_page={per_page}'
         return url
     except (AssertionError, Exception) as e:
         raise e


### PR DESCRIPTION
* list more entries per request -> fewer requests, faster sync
* do not crash if a file is present in the upload cache, but no longer on disk -> print a warning and continue