### PR TITLE
Add support for automatic token refresh in uploads and downloads

### DIFF
--- a/tsdapiclient/administrator.py
+++ b/tsdapiclient/administrator.py
@@ -15,7 +15,7 @@ def get_tsd_api_key(
     user_name: str,
     password: str,
     otp: str,
-    auth_method:str = 'tsd'
+    auth_method: str = 'tsd',
 ) -> str:
     headers = {'Content-Type': 'application/json'}
     data = {'user_name': user_name, 'password': password, 'otp': otp}

--- a/tsdapiclient/authapi.py
+++ b/tsdapiclient/authapi.py
@@ -4,8 +4,6 @@
 import json
 import requests
 
-from typing import Optional
-
 from tsdapiclient.client_config import ENV
 from tsdapiclient.tools import handle_request_errors, auth_api_url
 
@@ -15,7 +13,7 @@ def get_jwt_basic_auth(
     pnum: str,
     api_key: str,
     token_type: str = 'import',
-) -> Optional[str]:
+) -> tuple:
     headers = {
         'Content-Type': 'application/json',
         'Authorization': f'Bearer {api_key}'
@@ -26,10 +24,10 @@ def get_jwt_basic_auth(
     except Exception as e:
         raise e
     if resp.status_code in [200, 201]:
-        token = json.loads(resp.text)['token']
-        return token
+        data = json.loads(resp.text)
+        return data.get('token'), data.get('refresh_token')
     else:
-        return None
+        return None, None
 
 @handle_request_errors
 def get_jwt_two_factor_auth(
@@ -40,8 +38,8 @@ def get_jwt_two_factor_auth(
     password: str,
     otp: str,
     token_type: str,
-    auth_method: str = "tsd" 
-) -> Optional[str]:
+    auth_method: str = "tsd"
+) -> tuple:
     headers = {
         'Content-Type': 'application/json',
         'Authorization': f'Bearer {api_key}',
@@ -57,7 +55,7 @@ def get_jwt_two_factor_auth(
     except Exception as e:
         raise e
     if resp.status_code in [200, 201]:
-        token = json.loads(resp.text)['token']
-        return token
+        data = json.loads(resp.text)
+        return data.get('token'), data.get('refresh_token')
     else:
-        return None
+        return None, None

--- a/tsdapiclient/authapi.py
+++ b/tsdapiclient/authapi.py
@@ -59,3 +59,26 @@ def get_jwt_two_factor_auth(
         return data.get('token'), data.get('refresh_token')
     else:
         return None, None
+
+@handle_request_errors
+def refresh_access_token(
+    env: str,
+    pnum: str,
+    api_key: str,
+    refresh_token: str,
+) -> tuple:
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {api_key}',
+    }
+    data = {'refresh_token': refresh_token}
+    url = f'{auth_api_url(env, pnum, auth_method="refresh")}'
+    try:
+        resp = requests.post(url, data=json.dumps(data), headers=headers)
+    except Exception as e:
+        raise e
+    if resp.status_code in [200, 201]:
+        data = json.loads(resp.text)
+        return data.get('token'), data.get('refresh_token')
+    else:
+        return None, None

--- a/tsdapiclient/fileapi.py
+++ b/tsdapiclient/fileapi.py
@@ -744,7 +744,7 @@ def _complete_resumable(
     bar: Bar,
     session: Any = requests,
     mtime: Optional[str] = None,
-):
+) -> dict:
     headers = {'Authorization': 'Bearer {0}'.format(token)}
     if mtime:
         headers['Modified-Time'] = mtime

--- a/tsdapiclient/session.py
+++ b/tsdapiclient/session.py
@@ -63,8 +63,7 @@ def session_update(
         pass # use default
     target = data.get(env, {}).get(pnum, {})
     target[token_type] = token
-    if refresh_token:
-        target[f'{token_type}_refresh'] = refresh_token
+    target[f'{token_type}_refresh'] = refresh_token
     data[env][pnum] = target
     debug_step('updating session')
     with open(SESSION_STORE, 'w') as f:

--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -508,7 +508,7 @@ def cli(
             if not api_key:
                 api_key = get_api_key(env, pnum)
             username, password, otp = get_user_credentials()
-            token = get_jwt_two_factor_auth(
+            token, refresh_token = get_jwt_two_factor_auth(
                 env, pnum, api_key, username, password, otp, token_type, auth_method=auth_method,
             )
             if token:
@@ -525,7 +525,7 @@ def cli(
         if not api_key:
             api_key = get_api_key(env, pnum)
         debug_step('using basic authentication')
-        token = get_jwt_basic_auth(env, pnum, api_key)
+        token, refresh_token = get_jwt_basic_auth(env, pnum, api_key)
     if (requires_user_credentials or basic) and not token:
         click.echo('authentication failed')
         sys.exit(1)

--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -23,7 +23,8 @@ from tsdapiclient.fileapi import (streamfile, initiate_resumable, get_resumable,
 from tsdapiclient.guide import (topics, config, uploads, downloads,
                                 debugging, automation, sync)
 from tsdapiclient.session import (session_is_expired, session_expires_soon,
-                                  session_update, session_clear, session_token)
+                                  session_update, session_clear, session_token,
+                                  session_refresh_token)
 from tsdapiclient.sync import (SerialDirectoryUploader,
                                SerialDirectoryDownloader,
                                SerialDirectoryUploadSynchroniser,
@@ -513,10 +514,11 @@ def cli(
             )
             if token:
                 debug_step('updating login session')
-                session_update(env, pnum, token_type, token)
+                session_update(env, pnum, token_type, token, refresh_token)
         else:
             debug_step(f'using token from existing login session')
             token = session_token(env, pnum, token_type)
+            refresh_token = session_refresh_token(env, pnum, token_type)
     elif not requires_user_credentials and basic:
         if not pnum:
             click.echo('missing pnum argument')


### PR DESCRIPTION
This PR solves https://github.com/unioslo/tsd-api-client/issues/78 by implementing automatic token refresh for uploads and downloads.

The most important part is in the `authapi.py` module, in the `maybe_refresh` function. This function is called by all the functions in the `fileapi.py` module which perform data transfer, or deletion. Before making the respective HTTP request, each function calls the `maybe_refresh` function, replacing the current access and refresh tokens with new ones when the current access token nears expiry. Then it performs the request and returns the new tokens along with its response. In this way, callers of the functions definded in the `fileapi.py` module (e.g. in `sync.GenericDirectoryTransporter`) can reuse the newly refreshed tokens in subsequent function calls.

Overall this is a major UX improvement, allowing large (and most notably long-running) data transfer to be performed securely, without relying on very long token lifetimes.