### PR TITLE
Add more robustness to various requests

### DIFF
--- a/tsdapiclient/authapi.py
+++ b/tsdapiclient/authapi.py
@@ -7,6 +7,7 @@ import time
 
 from datetime import datetime, timedelta
 
+from tsdapiclient.exc import AuthnError
 from tsdapiclient.client_config import ENV
 from tsdapiclient.session import session_update
 from tsdapiclient.tools import handle_request_errors, auth_api_url, debug_step, get_claims
@@ -26,7 +27,7 @@ def get_jwt_basic_auth(
     try:
         resp = requests.post(url, headers=headers)
     except Exception as e:
-        raise e
+        raise AuthnError from e
     if resp.status_code in [200, 201]:
         data = json.loads(resp.text)
         return data.get('token'), data.get('refresh_token')
@@ -57,7 +58,7 @@ def get_jwt_two_factor_auth(
     try:
         resp = requests.post(url, data=json.dumps(data), headers=headers)
     except Exception as e:
-        raise e
+        raise AuthnError from e
     if resp.status_code in [200, 201]:
         data = json.loads(resp.text)
         return data.get('token'), data.get('refresh_token')
@@ -81,7 +82,7 @@ def refresh_access_token(
         debug_step('refreshing token')
         resp = requests.post(url, data=json.dumps(data), headers=headers)
     except Exception as e:
-        raise e
+        raise AuthnError from e
     if resp.status_code in [200, 201]:
         data = json.loads(resp.text)
         return data.get('token'), data.get('refresh_token')

--- a/tsdapiclient/authapi.py
+++ b/tsdapiclient/authapi.py
@@ -99,7 +99,7 @@ def maybe_refresh(
     refresh_token: str,
     refresh_target: int,
     before_min: int = 5,
-    after_min: int = 1,
+    after_min: int = 10,
     force: bool = False,
 ) -> dict:
     """

--- a/tsdapiclient/exc.py
+++ b/tsdapiclient/exc.py
@@ -1,0 +1,10 @@
+
+# Authentication errors
+
+class AuthnError(Exception):
+    pass
+
+# Authorization errors
+
+class AuthzError(Exception):
+    pass

--- a/tsdapiclient/fileapi.py
+++ b/tsdapiclient/fileapi.py
@@ -6,7 +6,7 @@ import json
 import os
 
 from functools import cmp_to_key
-from typing import Optional, Union, Any
+from typing import Optional, Union, Any, Iterable
 from urllib.parse import quote, unquote
 
 import humanfriendly
@@ -90,6 +90,8 @@ def upload_resource_name(filename: str, is_dir: bool, group: Optional[str] = Non
     if not is_dir:
         debug_step('uploading file')
         resource = quote(format_filename(filename))
+        if group:
+            resource = f'{group}/{resource}'
     elif is_dir:
         debug_step('uploading directory (file)')
         if filename.startswith('/'):
@@ -111,7 +113,7 @@ def lazy_reader(
     public_key: Optional[libnacl.public.PublicKey] = None,
     nonce: Optional[bytes] = None,
     key: Optional[bytes] = None,
-) -> Union[bytes, tuple]:
+) -> Union[Iterable[bytes], Iterable[tuple]]:
     """
     Create an iterator over a file, returning chunks of bytes.
 

--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -573,7 +573,7 @@ def cli(
         if upload:
             if os.path.isfile(upload):
                 if upload_id or os.stat(upload).st_size > as_bytes(resumable_threshold):
-                    debug_step('starting resumable upload')
+                    debug_step(f'starting resumable upload')
                     resp = initiate_resumable(
                         env,
                         pnum,

--- a/tsdapiclient/tools.py
+++ b/tsdapiclient/tools.py
@@ -15,11 +15,15 @@ from typing import Optional, Callable, Any
 
 import click
 
-from requests.exceptions import (ConnectionError, HTTPError, RequestException,
-                                 Timeout)
-
 from . import __version__
+from requests.exceptions import (
+    ConnectionError,
+    HTTPError,
+    RequestException,
+    Timeout,
+)
 from tsdapiclient.client_config import API_VERSION
+from tsdapiclient.exc import AuthzError, AuthnError
 
 HELP_URL = 'https://www.uio.no/english/services/it/research/sensitive-data/contact/index.html'
 
@@ -158,6 +162,12 @@ def handle_request_errors(f: Callable) -> Any:
         except RequestException as err:
             print(err)
             sys.exit("An error has occured. Exiting.")
+        except AuthzError as err:
+            print(err)
+            sys.exit("Request not authorized. Exiting.")
+        except AuthnError as err:
+            print(err)
+            sys.exit("Authentication failed. Exiting.")
     return decorator
 
 def _get_system_config_path() -> pathlib.Path:


### PR DESCRIPTION
Details:
* if getting the public key fails, we handle the error correctly
* when uploading to a custom group, ensure correct URL
* retry resumable requests on timeouts (up to 5 times)
* increase the refresh window