### PR TITLE
Implement a reconnect strategy for uploads

### DIFF
--- a/tsdapiclient/sync.py
+++ b/tsdapiclient/sync.py
@@ -479,6 +479,9 @@ class GenericDirectoryTransporter(object):
                 refresh_token=self.refresh_token,
                 refresh_target=self.refresh_target,
             )
+        if resp.get("session"):
+            debug_step("renewing session")
+            self.session = resp.get("session")
         if resp.get('tokens'):
             self.token = resp.get('tokens').get('access_token')
             self.refresh_token = resp.get('tokens').get('refresh_token')

--- a/tsdapiclient/tools.py
+++ b/tsdapiclient/tools.py
@@ -307,5 +307,5 @@ class Retry(object):
             else:
                 return {"resp": self.resp, "new_session": new_session}
 
-    def __exit__(self, type, value, traceback) -> requests.Response:
-        return self.resp # caller should raise from that
+    def __exit__(self, type, value, traceback) -> dict:
+        return {"resp": self.resp, "new_session": None} # caller should raise from that

--- a/tsdapiclient/tools.py
+++ b/tsdapiclient/tools.py
@@ -284,7 +284,6 @@ class Retry(object):
         retry_attempt_no = 0
         while self.counter > 0:
             try:
-                raise ConnectionError
                 self.resp = self.func(self.url, headers=self.headers, data=self.data)
             except KeyboardInterrupt:
                 sys.exit()


### PR DESCRIPTION
In this incarnation we try an upload, and if we get a `ConnectionError` during the upload, we wait 5 seconds, try to reconnect and then continue retries until we have reached the max retries.