### PR TITLE
Fix Click incompatibility and authorization errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=['tsdapiclient'],
     install_requires = [
         'requests',
-        'click',
+        'click>=8.0',
         'PyYAML',
         'progress',
         'humanfriendly',

--- a/tsdapiclient/administrator.py
+++ b/tsdapiclient/administrator.py
@@ -22,4 +22,5 @@ def get_tsd_api_key(
     url = f'{ENV[env]}/{pnum}/auth/{auth_method}/api_key'
     print('GET: {0}'.format(url))
     resp = requests.get(url, headers=headers, data=json.dumps(data))
+    resp.raise_for_status()
     return json.loads(resp.text)['api_key']

--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -191,14 +191,14 @@ def construct_correct_upload_path(path: str) -> str:
     default=None,
     required=False,
     help='Print a guide',
-    autocompletion=get_guide_options
+    shell_complete=get_guide_options
 )
 @click.option(
     '--env',
     default='prod',
     help='API environment',
     show_default=True,
-    autocompletion=get_api_envs
+    shell_complete=get_api_envs
 )
 @click.option(
     '--group',
@@ -215,7 +215,7 @@ def construct_correct_upload_path(path: str) -> str:
     '--upload',
     default=None,
     required=False,
-    autocompletion=get_dir_contents,
+    shell_complete=get_dir_contents,
     help='Import a file or a directory located at given path'
 )
 @click.option(


### PR DESCRIPTION
The autocompletion Click parameter was renamed to shell_complete in Click 8.0, and removed in Click 8.1. Adjusted the tacl module accordingly.

Made authorization issues in the administrator lead to an HTTPError exception being raised, so that this is handled by the handle_request_errors decorator. Previously this would lead to a KeyError on trying to access the API key and a traceback being printed.

Example:

```console
(tsdapiclient) ➜  tsd-api-client git:(get_tsd_api_key_exception) ✗ tacl --register
Choose the API environment by typing one of the following numbers:
1 - for normal production usage
2 - for use over fx03 network
3 - for testing
4 - for Educloud normal production usage
5 - for Educloud testing
 > 4
username > adjasjdja
password > 
one time code > dsfjsdjfj
ec project > sdjfjsdjf
GET: https://api.fp.educloud.no/v1/sdjfjsdjf/auth/tsd/api_key
401 Client Error: Unauthorized for url: https://api.fp.educloud.no/v1/sdjfjsdjf/auth/tsd/api_key
The request was unsuccesful. Exiting.
```