### PR TITLE
Build package sdist when publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,9 +16,9 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade pip setuptools wheel build
       - name: Build the package
-        run: python setup.py bdist bdist_wheel
+        run: python -m build
       - name: Publish the package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
This PR switches to PyPA build for package builds.
https://github.com/pypa/build

The 'build' tool also supports PEP 517, and so this workflow should just keep working as-is even if we decide to move away from setuptools.