### PR TITLE
Add external IP address lookup on connectivity issues

### DIFF
--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -59,6 +59,7 @@ from tsdapiclient.sync import (
     DownloadDeleteCache,
 )
 from tsdapiclient.tools import (
+    EDUCLOUD_CONTACT_URL,
     HELP_URL,
     check_if_key_has_expired,
     get_external_ip_address,
@@ -216,6 +217,8 @@ def check_api_connection(env: str) -> None:
         debug_step('skipping connection test as a proxy is set')
         return
     if not has_api_connectivity(hostname=API_ENVS[env]):
+        org = "Educloud Research" if env.startswith("ec") else "TSD"
+        contact_url = EDUCLOUD_CONTACT_URL if env.startswith("ec") else HELP_URL
         sys.exit(
             dedent(f'''\
                 The selected API environment appears to be inaccessible from your current network connection.
@@ -226,8 +229,8 @@ def check_api_connection(env: str) -> None:
                 - API environment: {env} ({ENV[env]})
                 - External IPv4 address: {get_external_ip_address()}
 
-                Please copy the above information and contact TSD for help:
-                {HELP_URL}'''
+                Please copy the above information and contact {org} for help:
+                {contact_url}'''
             )
         )
 

--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -116,6 +116,8 @@ GUIDES = {
     'encryption': encryption,
 }
 
+ENV_HTTPS_PROXY = "https_proxy"
+
 def print_version_info() -> None:
     version_text = """\
         tacl v{version}
@@ -205,7 +207,7 @@ def get_api_key(env: str, pnum: str) -> str:
 def check_api_connection(env: str) -> None:
     if env == "dev":
         return
-    if os.getenv("HTTPS_PROXY"):
+    if ENV_HTTPS_PROXY.casefold() in [s.casefold() for s in os.environ]:
         debug_step('skipping connection test as a proxy is set')
         return
     if not has_api_connectivity(hostname=API_ENVS[env]):

--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -60,6 +60,7 @@ from tsdapiclient.sync import (
 from tsdapiclient.tools import (
     HELP_URL,
     check_if_key_has_expired,
+    get_external_ip_address,
     has_api_connectivity,
     user_agent,
     debug_step,
@@ -214,6 +215,7 @@ def check_api_connection(env: str) -> None:
         sys.exit(
             dedent(f'''\
                 The API environment hosted at {ENV[env]} is not accessible from your current network connection.
+                Your external IP address is {get_external_ip_address()}.
                 Please contact TSD for help: {HELP_URL}'''
             )
         )

--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -4,6 +4,7 @@ import os
 import platform
 import sys
 
+from dataclasses import dataclass
 from textwrap import dedent
 from typing import Optional
 
@@ -119,18 +120,21 @@ GUIDES = {
 
 ENV_HTTPS_PROXY = "https_proxy"
 
+
+@dataclass(frozen=True)
+class SoftwareInfo:
+    version: str = __version__
+    os: str = platform.system()
+    cpu_arch: str = platform.uname().machine
+    python_version: str = platform.python_version()
+
+
 def print_version_info() -> None:
-    version_text = """\
-        tacl v{version}
-        - OS/Arch: {os}/{arch}
-        - Python: {pyver}\
-    """.format(
-        version=__version__,
-        os=platform.system(),
-        arch=platform.uname().machine,
-        pyver=platform.python_version()
-    )
-    print(dedent(version_text))
+    print(dedent(f"""\
+        tacl v{SoftwareInfo.version}
+        - OS/Arch: {SoftwareInfo.os}/{SoftwareInfo.cpu_arch}
+        - Python: {SoftwareInfo.python_version}\
+    """))
 
 
 def get_api_envs(ctx: str, args: list, incomplete: str) -> list:
@@ -214,9 +218,16 @@ def check_api_connection(env: str) -> None:
     if not has_api_connectivity(hostname=API_ENVS[env]):
         sys.exit(
             dedent(f'''\
-                The API environment hosted at {ENV[env]} is not accessible from your current network connection.
-                Your external IP address is {get_external_ip_address()}.
-                Please contact TSD for help: {HELP_URL}'''
+                The selected API environment appears to be inaccessible from your current network connection.
+
+                Technical details:
+                - {__package__} version {SoftwareInfo.version}
+                - Python {SoftwareInfo.python_version} on {SoftwareInfo.os}/{SoftwareInfo.cpu_arch}
+                - API environment: {env} ({ENV[env]})
+                - External IPv4 address: {get_external_ip_address()}
+
+                Please copy the above information and contact TSD for help:
+                {HELP_URL}'''
             )
         )
 

--- a/tsdapiclient/tools.py
+++ b/tsdapiclient/tools.py
@@ -27,6 +27,7 @@ from tsdapiclient.client_config import API_VERSION
 from tsdapiclient.exc import AuthzError, AuthnError
 
 HELP_URL = 'https://www.uio.no/english/services/it/research/sensitive-data/contact/index.html'
+EDUCLOUD_CONTACT_URL = "https://www.uio.no/english/services/it/research/platforms/edu-research/help/contact-us.html"
 
 HOSTS = {
     'test': 'test.api.tsd.usit.no',

--- a/tsdapiclient/tools.py
+++ b/tsdapiclient/tools.py
@@ -38,6 +38,9 @@ HOSTS = {
     'dev': 'localhost:3003',
 }
 
+IP_LOOKUP_API_URL = "https://api.ipify.org"
+
+
 def auth_api_url(env: str, pnum: str, auth_method: str) -> str:
     endpoints = {
         'default': {
@@ -231,6 +234,14 @@ def has_api_connectivity(hostname: str, port: int = 443, timeout: float = 0.5) -
     except:
         pass
     return connectivity
+
+
+def get_external_ip_address(timeout: float = 5) -> str:
+    try:
+        ip_address_request = requests.get(IP_LOOKUP_API_URL, timeout=timeout)
+    except:
+        return "UNKNOWN"
+    return ip_address_request.text
 
 
 def as_bytes(amount: str) -> int:


### PR DESCRIPTION
* Case insensitive checking for `https_proxy` env var
  * We were only looking for `HTTPS_PROXY`, but the "de facto" standard is lowercase for this one. It's best to check for both.
* Added [ipify](https://www.ipify.org/) utilizing external IPv4 address lookup
  * The lookup is performed after API connectivity has failed for the output help text.
* Added technical details from `tacl --version` to the connection error output, urging users to copy this in when contacting support.
* Tell Educloud Research users to contact Educloud Research support instead of TSD.

```console
➜  ~ tacl --register
Choose the API environment by typing one of the following numbers:
1 - for normal production usage
2 - for use over fx03 network
3 - for testing
4 - for Educloud normal production usage
5 - for Educloud testing
 > 5
The selected API environment appears to be inaccessible from your current network connection.

Technical details:
- tsdapiclient version 3.5.9.dev4+1a130d8
- Python 3.11.3 on Darwin/arm64
- API environment: ec-test (https://test.api.fp.educloud.no/v1)
- External IPv4 address: $ip_address

Please copy the above information and contact Educloud Research for help:
https://www.uio.no/english/services/it/research/platforms/edu-research/help/contact-us.html
```