### PR TITLE
Use HTTPS for connectivity checks

### DIFF
--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -211,6 +211,8 @@ def get_api_key(env: str, pnum: str) -> str:
 
 
 def check_api_connection(env: str) -> None:
+    if os.getenv("TACL_DISABLE_API_CONNECTION_CHECK"):
+        return
     if env == "dev":
         return
     if ENV_HTTPS_PROXY.casefold() in [s.casefold() for s in os.environ]:

--- a/tsdapiclient/tools.py
+++ b/tsdapiclient/tools.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import os
 import pathlib
-import socket
 import sys
 import time
 
@@ -224,14 +223,28 @@ def get_data_path(env: str, pnum: str) -> str:
     return str(data_path)
 
 
-def has_api_connectivity(hostname: str, port: int = 443, timeout: float = 0.5) -> bool:
+def has_api_connectivity(
+    hostname: str,
+    port: int = 443,
+    timeout: float = 0.5,
+    schema: str = "https",
+) -> bool:
+    """Verify that a connection can be made to the API.
+
+    Args:
+        hostname (str): domain where the API is hosted
+        port (int, optional): TCP port the API is listening on. Defaults to 443.
+        timeout (float, optional): how long to wait for a response. Defaults to 0.5 seconds.
+        schema (str, optional): protocol to use. Defaults to "https".
+
+    Returns:
+        bool: _description_
+    """
     connectivity = False
     try:
-        sock = socket.socket()
-        sock.settimeout(timeout)
-        sock.connect((hostname, port))
-        connectivity = True
-        sock.close()
+        r = requests.get(f"{schema}://{hostname}:{port}", timeout=timeout)
+        if r.status_code != 403:
+            connectivity = True
     except:
         pass
     return connectivity


### PR DESCRIPTION
In Educloud, non-HTTP(s) traffic is not being routed out to external IPv4 hosts, so our previous connectivity test using a TCP socket would fail there despite the API being usable.

I've rewritten the check to perform a GET for the domain root using requests, with anything other than 403 being accepted as success, as we don't currently offer any kind of info or health endpoint that could be used here.

The PR also adds an environment variable for just disabling all checks outright. If TACL_DISABLE_API_CONNECTION_CHECK is set, no checks will be run.