### PR TITLE
Fix bug in file_api_url when page is set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 maintainers = [
     "Eirik Haatveit <haatveit@uio.no>",
     "Milen Kouylekov <milen@uio.no>",
+    "Torjus Håkestad <torjus@uio.no>",
 ]
 license = "BSD-3-Clause"
 readme = "README.md"

--- a/tsdapiclient/tools.py
+++ b/tsdapiclient/tools.py
@@ -11,6 +11,7 @@ import time
 
 from functools import wraps
 from typing import Optional, Callable, Any, Union
+from urllib.parse import urlencode
 
 import click
 import requests
@@ -79,24 +80,26 @@ def file_api_url(
     service: str,
     endpoint: str = '',
     formid: str = '',
-    page: Optional[str] = None,
+    page: Optional[int] = None,
     per_page: Optional[int] = None,
 ) -> str:
     try:
         host = HOSTS.get(env)
-        if page:
-            url = f'https://{host}{page}'
-            if per_page:
-                url += f'&per_page={per_page}'
-            return url
         if formid:
             endpoint = f'{formid}/{endpoint}'
         scheme = 'http' if env == 'dev' else 'https'
         url = f'{scheme}://{host}/{API_VERSION}/{pnum}/{service}/{endpoint}'
         if url.endswith('/'):
             url = url[:-1]
+
+        query_dict = {}
         if per_page:
-            url += f'?per_page={per_page}'
+            query_dict["per_page"] = per_page
+        if page is not None:
+            query_dict["page"] = page
+        if len(query_dict) > 0:
+            url += f'?{urlencode(query_dict)}'
+
         return url
     except (AssertionError, Exception) as e:
         raise e


### PR DESCRIPTION
`file_api_url` returned invalid URL when page was supplied. For example:

```
file_api_url("test", "p1336", "survey", "123/attachments", per_page=50,page=1)
'https://test.api.tsd.usit.no1&per_page=50
```

This should fix this, making it return the expected value:
```
file_api_url("test", "p1336", "survey", "123/attachments", per_page=50,page=1)
'https://test.api.tsd.usit.no/v1/p1336/survey/123/attachments?per_page=50&page=1'
```

Also changes type annotation for page from `str` to `int`.