### PR TITLE
Add automated container builds

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,97 @@
+name: Build container
+
+on:
+  push:
+    paths:
+      - .github/workflows/container.yaml
+      - Containerfile
+      - pyproject.toml
+      - poetry.lock
+      - tsdapiclient/**
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  PYTHON_VERSION: "3.12"
+  POETRY_VERSION: "1.3.2"
+  POETRY_DYNAMIC_VERSIONING_VERSION: "1.1.0"
+  QEMU_PLATFORMS: "linux/amd64,linux/arm64"
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.pdv.outputs.version }}
+      tags: ${{ steps.meta.outputs.tags }}
+      labels: ${{ steps.meta.outputs.labels }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Poetry
+        run: pipx install poetry==${{env.POETRY_VERSION}}
+      - name: Install poetry-dynamic-versioning
+        run: pipx inject poetry "poetry-dynamic-versioning[plugin]==${{env.POETRY_DYNAMIC_VERSIONING_VERSION}}"
+      - name: Get version
+        run: echo "version=$(poetry version --short --no-ansi)" >> $GITHUB_OUTPUT
+        id: pdv
+      - name: Extract metadata (tags, labels) for container
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=raw,value=${{ steps.pdv.outputs.version }},priority=50
+            type=sha,prefix=,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          labels: |
+            org.opencontainers.image.version=${{ steps.pdv.outputs.version }}
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: metadata
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Log in to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      -
+        # Add support for more platforms with QEMU
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ env.QEMU_PLATFORMS }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push container image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: |
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            POETRY_VERSION=${{ env.POETRY_VERSION }}
+            POETRY_DYNAMIC_VERSIONING_VERSION=${{ env.POETRY_DYNAMIC_VERSIONING_VERSION }}
+          platforms: ${{ env.QEMU_PLATFORMS }}
+          file: "Containerfile"
+          push: true
+          tags: ${{ needs.metadata.outputs.tags }}
+          labels: ${{ needs.metadata.outputs.labels }}

--- a/Containerfile
+++ b/Containerfile
@@ -32,5 +32,5 @@ LABEL org.opencontainers.image.title="TSD API Client" \
       org.opencontainers.image.source="https://github.com/unioslo/tsd-api-client"
 ENTRYPOINT [ "/app/bin/tacl" ]
 ENV XDG_CONFIG_HOME=/config
-VOLUME [ "/config" ]
+VOLUME [ "/config/tacl" ]
 COPY --from=builder /app /app

--- a/README.md
+++ b/README.md
@@ -37,20 +37,46 @@ eval (env _TACL_COMPLETE=source_fish tacl)
 
 ## Running in a container
 
-First build the container from this repo:
+You can run the container like this:
 
 ```console
-git clone https://github.com/unioslo/tsd-api-client.git
-cd tsd-api-client
-podman build -t tsd-api-client .
+$ podman run --rm -ti ghcr.io/unioslo/tsd-api-client
+tacl --help, for basic help
+tacl --guide topics, for extended help
 ```
 
-Then run it, mounting a volume for saving configuration to `/config` in the
-container:
+The container entrypoint is `tacl`, meaning you can pass runtime parameters to
+the `ghcr.io/unioslo/tsd-api-client` image as if you were running `tacl` on your
+host.
 
 ```console
-podman run --rm -ti -v $HOME/.config/tacl:/config/tacl tsd-api-client --register
+$ podman run --rm -ti ghcr.io/unioslo/tsd-api-client --version
+tacl v3.5.13
+- OS/Arch: Linux/aarch64
+- Python: 3.12.2
+```
+
+You should bind mount a writable volume to `/config/tacl` in the container, so
+that your configuration and session data persists between separate invocation.
+
+```console
+$ podman run --rm -ti -v $HOME/.config/tacl:/config/tacl ghcr.io/unioslo/tsd-api-client --register
+Choose the API environment by typing one of the following numbers:
+1 - for normal production usage
+2 - for use over fx03 network
+3 - for testing
+4 - for Educloud normal production usage
+5 - for Educloud testing
+ >
 ```
 
 Likely you will also want to bind mount in another volume to upload data from
 or write exported data to.
+
+```console
+$ podman run --rm -ti \
+    -v $HOME/.config/tacl:/config/tacl \
+    -v $PWD:/data \
+    ghcr.io/unioslo/tsd-api-client
+    p11 --upload /data/README.md
+/data/README.md ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00


### PR DESCRIPTION
Add a GHA workflow for automated container builds of commits to this repository.

This PR also updates the documentations to instruct in the use of this image, instead of telling people to manually build the container on their own host.

Note that the README instructions will not work until the next tagged release, because the `latest` tag will only be used [on tag events](https://github.com/docker/metadata-action/tree/v5/?tab=readme-ov-file#latest-tag).