### PR TITLE
Better UX for using tacl with API keys

### DIFF
--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -541,7 +541,7 @@ def cli(
         resume_delete_all or
         upload_sync
     ):
-        if basic:
+        if basic or api_key:
             requires_user_credentials, token_type = False, TOKENS[env]['upload']
         else:
             requires_user_credentials, token_type = True, TOKENS[env]['upload']


### PR DESCRIPTION
* allow reading from a file: https://github.com/unioslo/tsd-api-client/issues/137 - avoids api key in process lists
* auto-renew the key if expired
* ensure the key is used without user authentication for upload and similar requests