### PR TITLE
ci: add PR fast-forward merge workflows

### DIFF
--- a/.github/workflows/pr-merge-check.yaml
+++ b/.github/workflows/pr-merge-check.yaml
@@ -1,0 +1,19 @@
+name: Pull request mergability check
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+jobs:
+  check-pr-ff-merge:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checking if fast forward merging is possible
+        uses: sequoia-pgp/fast-forward@v1
+        with:
+          merge: false
+          comment: always

--- a/.github/workflows/pr-merge.yaml
+++ b/.github/workflows/pr-merge.yaml
@@ -1,0 +1,24 @@
+name: Pull request merge
+on:
+  issue_comment:
+    types: [created, edited]
+jobs:
+  pr-ff-merge:
+    # Only run if the comment contains a fast-forward triggering command.
+    if: ${{ ( contains(github.event.comment.body, '/fast-forward') ||
+              contains(github.event.comment.body, '!ff') ||
+              contains(github.event.comment.body, '!merge') )
+            && github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Fast forward merge
+        uses: sequoia-pgp/fast-forward@v1
+        with:
+          merge: true
+          comment: always


### PR DESCRIPTION
This PR allows users with write privileges commenting on a mergeable PR with `!merge`, `!ff` or `/fast-forward` to have a bot merge it for them. 