### PR TITLE
use pathlib consequently to avoid incorrect filepaths

### DIFF
--- a/tsdapiclient/sync.py
+++ b/tsdapiclient/sync.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import time
 import shutil
 import sqlite3
@@ -353,7 +354,7 @@ class GenericDirectoryTransporter(object):
                         break
                 if ignore_suffix:
                     continue
-                target = f'{directory}/{file}'
+                target = os.path.normpath(f'{directory}/{file}')
                 if self.sync_mtime:
                     integrity_reference = str(os.stat(target).st_mtime)
                 if self.target_dir:
@@ -398,7 +399,7 @@ class GenericDirectoryTransporter(object):
                 group=self.group,
                 backend=list_funcs[self.remote_key]['backend'],
                 per_page=10000, # for better sync performance
-                remote_path=self.remote_path,  
+                remote_path=self.remote_path,
             )
             found = out.get('files')
             next_page = out.get('page')
@@ -406,7 +407,7 @@ class GenericDirectoryTransporter(object):
                 for entry in found:
                     import os
                     subdir_and_resource = os.path.basename(entry.get("href"))
-                    ref = f'{path}/{subdir_and_resource}'
+                    ref = str(pathlib.Path(path) / subdir_and_resource)
                     ignore_prefix = False
                     # check if we should ignore it
                     for prefix in self.ignore_prefixes:
@@ -458,7 +459,7 @@ class GenericDirectoryTransporter(object):
             print(f'WARNING: could not find {resource} on local disk')
             return resource
         if os.stat(resource).st_size > self.chunk_threshold:
-            print(f'initiating resumable upload for {resource} {self.remote_path}')   
+            print(f'initiating resumable upload for {resource} {self.remote_path}')
             resp = initiate_resumable(
                 self.env,
                 self.pnum,
@@ -534,7 +535,7 @@ class GenericDirectoryTransporter(object):
             refresh_token=self.refresh_token,
             refresh_target=self.refresh_target,
             public_key=self.public_key,
-            remote_path=self.remote_path,   
+            remote_path=self.remote_path,
         )
         if resp.get('tokens'):
             self.token = resp.get('tokens').get('access_token')


### PR DESCRIPTION
In upload-sync, listing local files in subdirs added an extra slash. This lead to deleting files in upload dir every second time filesync ran. This fix makes use of pathlib similar to previous pr addressing remote files.
This pr also uses switches to using pathlib for other paths found by a simple search in the code base.