### PR TITLE
Windows compatibility fixes

### DIFF
--- a/tsdapiclient/fileapi.py
+++ b/tsdapiclient/fileapi.py
@@ -33,6 +33,7 @@ except OSError:
 from tsdapiclient.authapi import maybe_refresh
 from tsdapiclient.client_config import ENV, API_VERSION
 from tsdapiclient.tools import (
+    as_local_path,
     handle_request_errors,
     debug_step,
     HELP_URL,
@@ -68,7 +69,7 @@ class Bar:
 
 def _init_progress_bar(current_chunk: int, chunksize: int, filename: str) -> Bar:
     # this is an approximation, better than nothing
-    fsize = os.stat(filename).st_size
+    fsize = os.stat(as_local_path(filename)).st_size
     num_chunks = fsize / chunksize
     if fsize < chunksize:
         current_chunk = 1
@@ -171,7 +172,7 @@ def lazy_reader(
         enc_nonce = nacl_encrypt_header(public_key, nonce)
         enc_key = nacl_encrypt_header(public_key, key)
     debug_step(f'reading file: {filename} in chunks of {chunksize} bytes')
-    with open(filename, 'rb') as f:
+    with open(as_local_path(filename), 'rb') as f:
         if verify:
             debug_step('verifying chunk md5sum')
             f.seek(previous_offset)
@@ -260,7 +261,7 @@ def streamfile(
     headers = {'Authorization': f'Bearer {token}'}
     debug_step(f'streaming data to {url}')
     if set_mtime:
-        current_mtime = os.stat(filename).st_mtime
+        current_mtime = os.stat(as_local_path(filename)).st_mtime
         headers['Modified-Time'] = str(current_mtime)
     if public_key:
         nonce, key = nacl_gen_nonce(), nacl_gen_key()
@@ -577,8 +578,8 @@ def export_get(
     if etag:
         debug_step(f'download_id: {etag}')
         filemode = 'ab'
-        if os.path.lexists(filename):
-            current_file_size = os.stat(filename).st_size
+        if os.path.lexists(as_local_path(filename)):
+            current_file_size = os.stat(as_local_path(filename)).st_size
             debug_step(f'found {filename} with {current_file_size} bytes')
             headers['Range'] = 'bytes={0}-'.format(current_file_size)
         else:
@@ -616,9 +617,9 @@ def export_get(
         bar = _init_export_progress_bar(unquote(filename), current_file_size, total_file_size, chunksize)
     filename = filename if not target_dir else os.path.normpath(f'{target_dir}/{filename}')
     destination_dir = os.path.dirname(filename)
-    if destination_dir and not os.path.lexists(destination_dir):
+    if destination_dir and not os.path.lexists(as_local_path(destination_dir)):
         debug_step(f'creating directory: {destination_dir}')
-        os.makedirs(destination_dir)
+        os.makedirs(as_local_path(destination_dir))
     if public_key:
         debug_step('generating nonce and key')
         nonce = nacl_gen_nonce()
@@ -630,7 +631,7 @@ def export_get(
         headers['Nacl-Chunksize'] = str(chunksize)
     with session.get(url, headers=headers, stream=True) as r:
         r.raise_for_status()
-        with open(unquote(filename), filemode) as f:
+        with open(as_local_path(unquote(filename)), filemode) as f:
             for chunk in r.iter_content(chunk_size=chunksize):
                 if chunk:
                     if public_key:
@@ -648,7 +649,7 @@ def export_get(
         try:
             mtime = float(resp.headers.get('Modified-Time'))
             debug_step(f'setting mtime for {filename} to {mtime}')
-            os.utime(filename, (mtime, mtime))
+            os.utime(as_local_path(filename), (mtime, mtime))
         except TypeError:
             print(f'{err}: {filename} - {err_consequence}')
             print('issue most likely due to not getting the correct header from the API')
@@ -951,7 +952,7 @@ def _start_resumable(
     """
     url = _resumable_url(env, pnum, filename, dev_url, backend, is_dir, group=group, remote_path=remote_path)
     headers = {'Authorization': f'Bearer {token}'}
-    current_mtime = os.stat(filename).st_mtime if set_mtime else None
+    current_mtime = os.stat(as_local_path(filename)).st_mtime if set_mtime else None
     if set_mtime:
         headers['Modified-Time'] = str(current_mtime)
     chunk_num = 1
@@ -1041,7 +1042,7 @@ def _continue_resumable(
     tokens = {}
     url = _resumable_url(env, pnum, filename, dev_url, backend, is_dir, group=group, remote_path=remote_path)
     headers = {'Authorization': f'Bearer {token}'}
-    current_mtime = os.stat(filename).st_mtime if set_mtime else None
+    current_mtime = os.stat(as_local_path(filename)).st_mtime if set_mtime else None
     if set_mtime:
         headers['Modified-Time'] = str(current_mtime)
     max_chunk = to_resume['max_chunk']

--- a/tsdapiclient/fileapi.py
+++ b/tsdapiclient/fileapi.py
@@ -127,6 +127,8 @@ def upload_resource_name(filename: str, is_dir: bool, group: Optional[str] = Non
             resource = group / resource
     else:
         debug_step('uploading directory (file)')
+        if os.sep != '/':
+            filename = filename.replace(os.sep, '/')
         if filename.startswith('/'):
             resource = pathlib.PurePosixPath(filename[1:])
         else:

--- a/tsdapiclient/sync.py
+++ b/tsdapiclient/sync.py
@@ -5,6 +5,7 @@ import sqlite3
 import sys
 
 from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
 from typing import ContextManager, Iterable, Optional
 
 import click
@@ -75,7 +76,7 @@ class GenericRequestCache(object):
     dbname = 'generic-request-cache.db'
 
     def __init__(self, env: str, pnum: str) -> None:
-        self.path = f'{get_data_path(env, pnum)}/{self.dbname}'
+        self.path = str(Path(get_data_path(env, pnum)) / self.dbname)
         try:
             self.engine = sqlite3.connect(self.path)
         except sqlite3.OperationalError as e:
@@ -330,14 +331,13 @@ class GenericDirectoryTransporter(object):
         exist remotely.
 
         """
-        path = path if not self.target_dir else os.path.normpath(f'{self.target_dir}/{path}')
+        path = path if not self.target_dir else str(Path(self.target_dir) / path)
         resources = []
         integrity_reference = None
         debug_step('finding local resources to transfer')
         for directory, subdirectory, files in os.walk(path):
-            if sys.platform == 'win32':
-                directory = directory.replace("\\", "/")
-            folder = directory.replace(f'{path}/', '')
+            rel_path = Path(directory).relative_to(path)
+            folder = directory if rel_path == Path('.') else str(rel_path)
             ignore_prefix = False
             for prefix in self.ignore_prefixes:
                 if folder.startswith(prefix):
@@ -353,12 +353,12 @@ class GenericDirectoryTransporter(object):
                         break
                 if ignore_suffix:
                     continue
-                target = f'{directory}/{file}'
+                target = Path(directory) / file
                 if self.sync_mtime:
-                    integrity_reference = str(os.stat(target).st_mtime)
+                    integrity_reference = str(target.stat().st_mtime)
                 if self.target_dir:
-                    target = os.path.normpath(target.replace(f'{self.target_dir}/', ''))
-                resources.append((target, integrity_reference))
+                    target = target.relative_to(Path(self.target_dir))
+                resources.append((str(target), integrity_reference))
         return resources
 
     def _find_remote_resources(self, path: str) -> list:
@@ -406,7 +406,7 @@ class GenericDirectoryTransporter(object):
                 for entry in found:
                     import os
                     subdir_and_resource = os.path.basename(entry.get("href"))
-                    ref = f'{path}/{subdir_and_resource}'
+                    ref = str(PurePosixPath(path) / subdir_and_resource)
                     ignore_prefix = False
                     # check if we should ignore it
                     for prefix in self.ignore_prefixes:
@@ -514,7 +514,7 @@ class GenericDirectoryTransporter(object):
 
         """
         target = os.path.dirname(resource)
-        target = target if not self.target_dir else os.path.normpath(f'{self.target_dir}/{target}')
+        target = target if not self.target_dir else str(Path(self.target_dir) / target)
         if not os.path.lexists(target):
             debug_step(f'creating directory: {target}')
             os.makedirs(target)

--- a/tsdapiclient/sync.py
+++ b/tsdapiclient/sync.py
@@ -332,12 +332,13 @@ class GenericDirectoryTransporter(object):
 
         """
         path = path if not self.target_dir else str(Path(self.target_dir) / path)
+        abs_path = Path(path).resolve()
         resources = []
         integrity_reference = None
         debug_step('finding local resources to transfer')
-        for directory, subdirectory, files in os.walk(path):
-            rel_path = Path(directory).relative_to(path)
-            folder = directory if rel_path == Path('.') else str(rel_path)
+        for directory, subdirectory, files in os.walk(abs_path):
+            rel_path = Path(directory).relative_to(abs_path)
+            folder = str(directory) if rel_path == Path('.') else str(rel_path)
             ignore_prefix = False
             for prefix in self.ignore_prefixes:
                 if folder.startswith(prefix):
@@ -353,11 +354,14 @@ class GenericDirectoryTransporter(object):
                         break
                 if ignore_suffix:
                     continue
-                target = Path(directory) / file
+                abs_target = Path(directory) / file
                 if self.sync_mtime:
-                    integrity_reference = str(target.stat().st_mtime)
+                    integrity_reference = str(abs_target.stat().st_mtime)
                 if self.target_dir:
-                    target = target.relative_to(Path(self.target_dir))
+                    target_dir_abs = Path(self.target_dir).resolve()
+                    target = abs_target.relative_to(target_dir_abs)
+                else:
+                    target = abs_target.relative_to(Path.cwd())
                 resources.append((str(target), integrity_reference))
         return resources
 

--- a/tsdapiclient/sync.py
+++ b/tsdapiclient/sync.py
@@ -1,12 +1,10 @@
 import os
-import time
 import shutil
 import sqlite3
-import sys
 
 from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
-from typing import ContextManager, Iterable, Optional
+from typing import ContextManager, Optional
 
 import click
 import humanfriendly.tables
@@ -14,14 +12,22 @@ import requests
 
 try:
     import libnacl.public
+
     LIBSODIUM_AVAILABLE = True
 except OSError:
     LIBSODIUM_AVAILABLE = False
 
-from tsdapiclient.fileapi import (streamfile, initiate_resumable, import_list,
-                                  export_list, export_get,
-                                  import_delete, export_delete, survey_list)
-from tsdapiclient.tools import debug_step, get_data_path, get_claims
+from tsdapiclient.fileapi import (
+    streamfile,
+    initiate_resumable,
+    import_list,
+    export_list,
+    export_get,
+    import_delete,
+    export_delete,
+    survey_list,
+)
+from tsdapiclient.tools import as_local_path, debug_step, get_data_path, get_claims
 
 
 @contextmanager
@@ -70,17 +76,16 @@ class CacheError(Exception):
 
 
 class GenericRequestCache(object):
-
     """sqlite-backed request cache."""
 
-    dbname = 'generic-request-cache.db'
+    dbname = "generic-request-cache.db"
 
     def __init__(self, env: str, pnum: str) -> None:
         self.path = str(Path(get_data_path(env, pnum)) / self.dbname)
         try:
             self.engine = sqlite3.connect(self.path)
         except sqlite3.OperationalError as e:
-            msg = f'cannot access request cache: {e}'
+            msg = f"cannot access request cache: {e}"
             raise CacheConnectionError(msg) from e
 
     def create(self, *, key: str) -> None:
@@ -93,15 +98,17 @@ class GenericRequestCache(object):
         try:
             with sqlite_session(self.engine) as session:
                 session.execute(
-                    f'create table if not exists {request_table_definition}'
+                    f"create table if not exists {request_table_definition}"
                 )
         except Exception as e:
-            msg = f'could not create request cache for {key}: {e}'
+            msg = f"could not create request cache for {key}: {e}"
             raise CacheCreationError(msg) from e
 
-    def add(self, *, key: str, item: str, integrity_reference: Optional[str] = None) -> tuple:
+    def add(
+        self, *, key: str, item: str, integrity_reference: Optional[str] = None
+    ) -> tuple:
         if not isinstance(item, str):
-            raise CacheItemTypeError('only string items allowed')
+            raise CacheItemTypeError("only string items allowed")
         try:
             with sqlite_session(self.engine) as session:
                 session.execute(
@@ -109,7 +116,7 @@ class GenericRequestCache(object):
                       values ('{item}', '{integrity_reference}')"
                 )
         except sqlite3.IntegrityError as e:
-            msg = f'{item} already cached for {key}'
+            msg = f"{item} already cached for {key}"
             raise CacheDuplicateItemError(msg) from e
         except sqlite3.OperationalError as e:
             msg = f"{e}, call: create(key='{key}')"
@@ -117,15 +124,17 @@ class GenericRequestCache(object):
         return (item, integrity_reference)
 
     def add_many(self, *, key: str, items: list) -> bool:
-        stmt = f'insert into "{os.path.basename(key)}"(resource_path, integrity_reference) \
+        stmt = (
+            f'insert into "{os.path.basename(key)}"(resource_path, integrity_reference) \
                  values (?, ?)'
+        )
         try:
             with sqlite_session(self.engine) as session:
                 session.executemany(stmt, items)
         except sqlite3.ProgrammingError as e:
-            raise CacheError(f'{e}') from e
+            raise CacheError(f"{e}") from e
         except sqlite3.IntegrityError as e:
-            msg = f'item already cached: {e} - delete cache and try again'
+            msg = f"item already cached: {e} - delete cache and try again"
             raise CacheDuplicateItemError(msg) from e
         except sqlite3.OperationalError as e:
             msg = f"{e}, call: create(key='{key}')"
@@ -143,7 +152,7 @@ class GenericRequestCache(object):
         try:
             with sqlite_session(self.engine) as session:
                 res = session.execute(
-                    f"select resource_path, integrity_reference from \"{os.path.basename(key)}\""
+                    f'select resource_path, integrity_reference from "{os.path.basename(key)}"'
                 ).fetchall()
         except sqlite3.OperationalError as e:
             msg = f"{e}, call: create(key='{key}')"
@@ -153,11 +162,9 @@ class GenericRequestCache(object):
     def destroy(self, *, key: str) -> bool:
         try:
             with sqlite_session(self.engine) as session:
-                session.execute(
-                    f"drop table if exists \"{os.path.basename(key)}\""
-                )
+                session.execute(f'drop table if exists "{os.path.basename(key)}"')
         except sqlite3.OperationalError as e:
-            msg = f'could not destroy cache for {key}: {e}'
+            msg = f"could not destroy cache for {key}: {e}"
             raise CacheDestroyError(msg) from e
         return True
 
@@ -169,7 +176,7 @@ class GenericRequestCache(object):
         if not all_tables:
             return []
         for table in all_tables[0]:
-            summary_query = f"select min(created_at), max(created_at) from \"{table}\""
+            summary_query = f'select min(created_at), max(created_at) from "{table}"'
             with sqlite_session(self.engine) as session:
                 summary = session.execute(summary_query).fetchall()[0]
                 data.append((table, summary[0], summary[1]))
@@ -177,13 +184,12 @@ class GenericRequestCache(object):
 
     def print(self) -> None:
         data = self.overview()
-        colnames = ['Cache key', 'Created at', 'Updated at']
+        colnames = ["Cache key", "Created at", "Updated at"]
         values = []
         for entry in data:
             row = [entry[0], entry[1], entry[2]]
             values.append(row)
         print(humanfriendly.tables.format_pretty_table(sorted(values), colnames))
-
 
     def destroy_all(self) -> None:
         data = self.overview()
@@ -194,28 +200,27 @@ class GenericRequestCache(object):
 
 
 class UploadCache(GenericRequestCache):
-    dbname = 'upload-request-cache.db'
+    dbname = "upload-request-cache.db"
 
 
 class DownloadCache(GenericRequestCache):
-    dbname = 'download-request-cache.db'
+    dbname = "download-request-cache.db"
 
 
 class GenericDeleteCache(GenericRequestCache):
-    dbname = 'generic-delete-cache.db'
+    dbname = "generic-delete-cache.db"
 
 
 class UploadDeleteCache(GenericDeleteCache):
-    dbname = 'update-delete-cache.db'
+    dbname = "update-delete-cache.db"
 
 
 class DownloadDeleteCache(GenericDeleteCache):
-    dbname = 'download-delete-cache.db'
+    dbname = "download-delete-cache.db"
 
 
 class GenericDirectoryTransporter(object):
-
-    transfer_cache_class =  GenericRequestCache
+    transfer_cache_class = GenericRequestCache
     delete_cache_class = GenericDeleteCache
 
     def __init__(
@@ -234,8 +239,8 @@ class GenericDirectoryTransporter(object):
         remote_key: Optional[str] = None,
         target_dir: Optional[str] = None,
         public_key: Optional["libnacl.public.PublicKey"] = None,
-        chunk_size: Optional[int] = 1000*1000*50,
-        chunk_threshold: Optional[int] = 1000*1000*1000,
+        chunk_size: Optional[int] = 1000 * 1000 * 50,
+        chunk_threshold: Optional[int] = 1000 * 1000 * 1000,
         api_key: Optional[str] = None,
         refresh_token: Optional[str] = None,
         refresh_target: Optional[int] = None,
@@ -255,7 +260,7 @@ class GenericDirectoryTransporter(object):
         self.ignore_prefixes = self._parse_ignore_data(prefixes)
         self.ignore_suffixes = self._parse_ignore_data(suffixes)
         self.sync_mtime = sync_mtime
-        self.integrity_reference_key = 'etag' if not sync_mtime else 'mtime'
+        self.integrity_reference_key = "etag" if not sync_mtime else "mtime"
         self.keep_missing = keep_missing
         self.keep_updated = keep_updated
         self.remote_key = remote_key
@@ -273,8 +278,8 @@ class GenericDirectoryTransporter(object):
         if not patterns:
             return []
         else:
-            debug_step(f'ignoring patterns: {patterns}')
-            return patterns.replace(' ', '').split(',')
+            debug_step(f"ignoring patterns: {patterns}")
+            return patterns.replace(" ", "").split(",")
 
     def sync(self) -> bool:
         """
@@ -288,14 +293,14 @@ class GenericDirectoryTransporter(object):
         deletes = []
         # 1. check caches
         if self.use_cache:
-            debug_step('reading from cache')
+            debug_step("reading from cache")
             left_overs = self.transfer_cache.read(key=self.directory)
             if left_overs:
-                click.echo('resuming directory transfer from cache')
+                click.echo("resuming directory transfer from cache")
                 resources = left_overs
             left_over_deletes = self.delete_cache.read(key=self.directory)
             if left_over_deletes:
-                click.echo('resuming deletion from cache')
+                click.echo("resuming deletion from cache")
                 deletes = left_over_deletes
         # 2. maybe find resources, maybe fill caches
         if not resources or not self.use_cache:
@@ -305,18 +310,18 @@ class GenericDirectoryTransporter(object):
                 self.delete_cache.add_many(key=self.directory, items=deletes)
         # 3. transfer resources
         for resource, integrity_reference in resources:
-            print(f'transferring: {resource}')
+            print(f"transferring: {resource}")
             self._transfer(resource, integrity_reference=integrity_reference)
             if self.use_cache:
                 self.transfer_cache.remove(key=self.directory, item=resource)
-        debug_step('destroying transfer cache')
+        debug_step("destroying transfer cache")
         self.transfer_cache.destroy(key=self.directory)
         # 4. maybe delete resources
         for resource, _ in deletes:
             self._delete(resource)
             if self.use_cache:
                 self.delete_cache.remove(key=self.directory, item=resource)
-        debug_step('destroying delete cache')
+        debug_step("destroying delete cache")
         self.delete_cache.destroy(key=self.directory)
         return True
 
@@ -335,10 +340,10 @@ class GenericDirectoryTransporter(object):
         abs_path = Path(path).resolve()
         resources = []
         integrity_reference = None
-        debug_step('finding local resources to transfer')
+        debug_step("finding local resources to transfer")
         for directory, subdirectory, files in os.walk(abs_path):
             rel_path = Path(directory).relative_to(abs_path)
-            folder = str(directory) if rel_path == Path('.') else str(rel_path)
+            folder = str(directory) if rel_path == Path(".") else str(rel_path)
             ignore_prefix = False
             for prefix in self.ignore_prefixes:
                 if folder.startswith(prefix):
@@ -356,7 +361,11 @@ class GenericDirectoryTransporter(object):
                     continue
                 abs_target = Path(directory) / file
                 if self.sync_mtime:
-                    integrity_reference = str(abs_target.stat().st_mtime)
+                    integrity_reference = str(
+                        os.stat(as_local_path(abs_target)).st_mtime
+                    )
+                # Convert back to relative path for storage/upload
+                # Make it relative to cwd to preserve the original directory structure
                 if self.target_dir:
                     target_dir_abs = Path(self.target_dir).resolve()
                     target = abs_target.relative_to(target_dir_abs)
@@ -372,27 +381,27 @@ class GenericDirectoryTransporter(object):
         Collect integrity references for all resources.
         """
 
-        print(f'finding remote resources for {path}')
+        print(f"finding remote resources for {path}")
         list_funcs = {
-            'export': {
-                'func': export_list,
-                'backend': 'files',
+            "export": {
+                "func": export_list,
+                "backend": "files",
             },
-            'import': {
-                'func': import_list,
-                'backend': 'files',
+            "import": {
+                "func": import_list,
+                "backend": "files",
             },
-            'survey': {
-                'func': survey_list,
-                'backend': 'survey',
-            }
+            "survey": {
+                "func": survey_list,
+                "backend": "survey",
+            },
         }
         resources = []
         subdirs = []
         next_page = None
         while True:
-            click.echo(f'fetching information about directory: {path}')
-            out = list_funcs[self.remote_key]['func'](
+            click.echo(f"fetching information about directory: {path}")
+            out = list_funcs[self.remote_key]["func"](
                 self.env,
                 self.pnum,
                 self.token,
@@ -400,27 +409,28 @@ class GenericDirectoryTransporter(object):
                 directory=path,
                 page=next_page,
                 group=self.group,
-                backend=list_funcs[self.remote_key]['backend'],
-                per_page=10000, # for better sync performance
-                remote_path=self.remote_path,  
+                backend=list_funcs[self.remote_key]["backend"],
+                per_page=10000,  # for better sync performance
+                remote_path=self.remote_path,
             )
-            found = out.get('files')
-            next_page = out.get('page')
+            found = out.get("files")
+            next_page = out.get("page")
             if found:
                 for entry in found:
                     import os
+
                     subdir_and_resource = os.path.basename(entry.get("href"))
                     ref = str(PurePosixPath(path) / subdir_and_resource)
                     ignore_prefix = False
                     # check if we should ignore it
                     for prefix in self.ignore_prefixes:
                         # because we ignore _sub_ directories
-                        target = ref.replace(f'{self.directory}/', '')
+                        target = ref.replace(f"{self.directory}/", "")
                         if target.startswith(prefix):
                             ignore_prefix = True
                             break
                     if ignore_prefix:
-                        debug_step(f'ignoring {ref}')
+                        debug_step(f"ignoring {ref}")
                         continue
                     ignore_suffix = False
                     for suffix in self.ignore_suffixes:
@@ -428,10 +438,10 @@ class GenericDirectoryTransporter(object):
                             ignore_suffix = True
                             break
                     if ignore_suffix:
-                        debug_step(f'ignoring {ref}')
+                        debug_step(f"ignoring {ref}")
                         continue
                     # track resource
-                    if entry.get('mime-type') == 'directory':
+                    if entry.get("mime-type") == "directory":
                         subdirs.append(ref)
                     else:
                         resources.append(
@@ -440,11 +450,11 @@ class GenericDirectoryTransporter(object):
             # follow next_page(s) for a given path, until exhaustively listed
             # break if no other subdirs were found
             if not next_page and not subdirs:
-                debug_step(f'found all files for {path}')
+                debug_step(f"found all files for {path}")
                 break
             if not next_page and subdirs:
                 path = subdirs.pop(0)
-                debug_step(f'finding files for sub-directory {path}')
+                debug_step(f"finding files for sub-directory {path}")
         return resources
 
     def _transfer_local_to_remote(
@@ -458,11 +468,11 @@ class GenericDirectoryTransporter(object):
         size of the $CHUNK_THRESHOLD.
 
         """
-        if not os.path.lexists(resource):
-            print(f'WARNING: could not find {resource} on local disk')
+        if not os.path.lexists(as_local_path(resource)):
+            print(f"WARNING: could not find {resource} on local disk")
             return resource
-        if os.stat(resource).st_size > self.chunk_threshold:
-            print(f'initiating resumable upload for {resource} {self.remote_path}')   
+        if os.stat(as_local_path(resource)).st_size > self.chunk_threshold:
+            print(f"initiating resumable upload for {resource} {self.remote_path}")
             resp = initiate_resumable(
                 self.env,
                 self.pnum,
@@ -499,10 +509,10 @@ class GenericDirectoryTransporter(object):
         if resp.get("session"):
             debug_step("renewing session")
             self.session = resp.get("session")
-        if resp.get('tokens'):
-            self.token = resp.get('tokens').get('access_token')
-            self.refresh_token = resp.get('tokens').get('refresh_token')
-            self.refresh_target = get_claims(self.token).get('exp')
+        if resp.get("tokens"):
+            self.token = resp.get("tokens").get("access_token")
+            self.refresh_token = resp.get("tokens").get("refresh_token")
+            self.refresh_target = get_claims(self.token).get("exp")
         return resource
 
     def _transfer_remote_to_local(
@@ -519,10 +529,10 @@ class GenericDirectoryTransporter(object):
         """
         target = os.path.dirname(resource)
         target = target if not self.target_dir else str(Path(self.target_dir) / target)
-        if not os.path.lexists(target):
-            debug_step(f'creating directory: {target}')
-            os.makedirs(target)
-        print(f'downloading: {resource}')
+        if not os.path.lexists(as_local_path(target)):
+            debug_step(f"creating directory: {target}")
+            os.makedirs(as_local_path(target))
+        print(f"downloading: {resource}")
         resp = export_get(
             self.env,
             self.pnum,
@@ -538,12 +548,12 @@ class GenericDirectoryTransporter(object):
             refresh_token=self.refresh_token,
             refresh_target=self.refresh_target,
             public_key=self.public_key,
-            remote_path=self.remote_path,   
+            remote_path=self.remote_path,
         )
-        if resp.get('tokens'):
-            self.token = resp.get('tokens').get('access_token')
-            self.refresh_token = resp.get('tokens').get('refresh_token')
-            self.refresh_target = get_claims(self.token).get('exp')
+        if resp.get("tokens"):
+            self.token = resp.get("tokens").get("access_token")
+            self.refresh_token = resp.get("tokens").get("refresh_token")
+            self.refresh_target = get_claims(self.token).get("exp")
         return resource
 
     def _delete_remote_resource(self, resource: str) -> str:
@@ -552,10 +562,10 @@ class GenericDirectoryTransporter(object):
 
         """
         delete_funcs = {
-            'export': export_delete,
-            'import': import_delete,
+            "export": export_delete,
+            "import": import_delete,
         }
-        debug_step(f'deleting: {resource}')
+        debug_step(f"deleting: {resource}")
         resp = delete_funcs[self.remote_key](
             self.env,
             self.pnum,
@@ -568,10 +578,10 @@ class GenericDirectoryTransporter(object):
             refresh_target=self.refresh_target,
             remote_path=self.remote_path,
         )
-        if resp.get('tokens'):
-            self.token = resp.get('tokens').get('access_token')
-            self.refresh_token = resp.get('tokens').get('refresh_token')
-            self.refresh_target = get_claims(self.token).get('exp')
+        if resp.get("tokens"):
+            self.token = resp.get("tokens").get("access_token")
+            self.refresh_token = resp.get("tokens").get("refresh_token")
+            self.refresh_target = get_claims(self.token).get("exp")
         return resource
 
     def _find_sync_lists(
@@ -608,18 +618,21 @@ class GenericDirectoryTransporter(object):
         # the integrity reference is not relevant
         # so None is passed as the second tuple value
         if not keep_missing:
-            target_names = set([ r for r, i in target ])
-            source_names = set([ r for r, i in source ])
-            deletes = [ (r, None) for r in target_names.difference(source_names) ]
+            target_names = set([r for r, i in target])
+            source_names = set([r for r, i in source])
+            deletes = [(r, None) for r in target_names.difference(source_names)]
         else:
             deletes = []
         if not keep_updated:
-            source_names_mtimes = set([ (r, i) for r, i in source ])
-            target_names_mtimes = set([ (r, i) for r, i in target ])
-            transfers = [ (r, None) for r, i in source_names_mtimes.difference(target_names_mtimes) ]
+            source_names_mtimes = set([(r, i) for r, i in source])
+            target_names_mtimes = set([(r, i) for r, i in target])
+            transfers = [
+                (r, None)
+                for r, i in source_names_mtimes.difference(target_names_mtimes)
+            ]
         else:
-            sources = { r: i for r, i in source }
-            remotes = { r: i for r, i in target }
+            sources = {r: i for r, i in source}
+            remotes = {r: i for r, i in target}
             transfers = []
             for k, v in sources.items():
                 if not remotes.get(k):
@@ -643,7 +656,9 @@ class GenericDirectoryTransporter(object):
         """
         raise NotImplementedError
 
-    def _transfer(self, resource: str, integrity_reference: Optional[str] = None) -> str:
+    def _transfer(
+        self, resource: str, integrity_reference: Optional[str] = None
+    ) -> str:
         """
         Transfer a given resource over the network.
 
@@ -664,8 +679,8 @@ class GenericDirectoryTransporter(object):
 
 # Implementations of specific transfers
 
-class SerialDirectoryUploader(GenericDirectoryTransporter):
 
+class SerialDirectoryUploader(GenericDirectoryTransporter):
     """Simple idempotent resumable directory upload."""
 
     transfer_cache_class = UploadCache
@@ -675,8 +690,9 @@ class SerialDirectoryUploader(GenericDirectoryTransporter):
         resources = self._find_local_resources(path)
         return resources, deletes
 
-
-    def _transfer(self, resource: str, integrity_reference: Optional[str] = None) -> str:
+    def _transfer(
+        self, resource: str, integrity_reference: Optional[str] = None
+    ) -> str:
         resource = self._transfer_local_to_remote(
             resource, integrity_reference=integrity_reference
         )
@@ -684,7 +700,6 @@ class SerialDirectoryUploader(GenericDirectoryTransporter):
 
 
 class SerialDirectoryDownloader(GenericDirectoryTransporter):
-
     """Simple idempotent resumable directory download."""
 
     transfer_cache_class = DownloadCache
@@ -694,7 +709,9 @@ class SerialDirectoryDownloader(GenericDirectoryTransporter):
         resources = self._find_remote_resources(path)
         return resources, deletes
 
-    def _transfer(self, resource: str, integrity_reference: Optional[str] = None) -> str:
+    def _transfer(
+        self, resource: str, integrity_reference: Optional[str] = None
+    ) -> str:
         resource = self._transfer_remote_to_local(
             resource, integrity_reference=integrity_reference
         )
@@ -702,7 +719,6 @@ class SerialDirectoryDownloader(GenericDirectoryTransporter):
 
 
 class SerialDirectoryUploadSynchroniser(GenericDirectoryTransporter):
-
     """
     Incremental, one-way, local-to-remote directory sync.
 
@@ -720,13 +736,16 @@ class SerialDirectoryUploadSynchroniser(GenericDirectoryTransporter):
         source = self._find_local_resources(path)
         target = self._find_remote_resources(path)
         resources, deletes = self._find_sync_lists(
-            source=source, target=target,
+            source=source,
+            target=target,
             keep_missing=self.keep_missing,
-            keep_updated=self.keep_updated
+            keep_updated=self.keep_updated,
         )
         return resources, deletes
 
-    def _transfer(self, resource: str, integrity_reference: Optional[str] = None) -> str:
+    def _transfer(
+        self, resource: str, integrity_reference: Optional[str] = None
+    ) -> str:
         resource = self._transfer_local_to_remote(
             resource, integrity_reference=integrity_reference
         )
@@ -738,7 +757,6 @@ class SerialDirectoryUploadSynchroniser(GenericDirectoryTransporter):
 
 
 class SerialDirectoryDownloadSynchroniser(GenericDirectoryTransporter):
-
     """
     Incremental, one-way, remote-to-local directory sync.
 
@@ -756,22 +774,26 @@ class SerialDirectoryDownloadSynchroniser(GenericDirectoryTransporter):
         target = self._find_local_resources(path)
         source = self._find_remote_resources(path)
         resources, deletes = self._find_sync_lists(
-            source=source, target=target,
+            source=source,
+            target=target,
             keep_missing=self.keep_missing,
-            keep_updated=self.keep_updated
+            keep_updated=self.keep_updated,
         )
         return resources, deletes
 
-    def _transfer(self, resource: str, integrity_reference: Optional[str] = None) -> str:
+    def _transfer(
+        self, resource: str, integrity_reference: Optional[str] = None
+    ) -> str:
         resource = self._transfer_remote_to_local(
             resource, integrity_reference=integrity_reference
         )
         return resource
 
     def _delete(self, resource: str) -> str:
-        print(f'deleting: {resource}')
-        if os.path.isdir(resource):
-            shutil.rmtree(resource)
+        print(f"deleting: {resource}")
+        local = as_local_path(resource)
+        if os.path.isdir(local):
+            shutil.rmtree(local)
         else:
-            os.remove(resource)
+            os.remove(local)
         return resource

--- a/tsdapiclient/tacl.py
+++ b/tsdapiclient/tacl.py
@@ -72,6 +72,7 @@ from tsdapiclient.tools import (
     get_claims,
     renew_api_key,
     display_instance_info,
+    as_local_path,
 )
 
 requests.utils.default_user_agent = user_agent
@@ -734,8 +735,8 @@ def cli(
             if token_path:
                 remote_path = f"{token_path}/"
         if upload:
-            if os.path.isfile(upload):
-                if upload_id or os.stat(upload).st_size > as_bytes(resumable_threshold):
+            if os.path.isfile(as_local_path(upload)):
+                if upload_id or os.stat(as_local_path(upload)).st_size > as_bytes(resumable_threshold):
                     debug_step(f'starting resumable upload')
                     resp = initiate_resumable(
                         env,

--- a/tsdapiclient/tools.py
+++ b/tsdapiclient/tools.py
@@ -258,6 +258,27 @@ def get_data_path(env: str, pnum: str) -> str:
     return str(data_path)
 
 
+def as_local_path(path) -> str:
+    r"""
+    Return a path suitable for local filesystem operations.
+
+    On Windows, prefixes the absolute path with \\?\ so that operations
+    succeed for paths exceeding MAX_PATH (260 characters). The prefix
+    tells Windows to pass the path directly to the filesystem API, which
+    supports paths up to ~32,767 characters. On other platforms the path
+    is returned unchanged.
+    """
+    path = str(path)
+    if sys.platform != 'win32':
+        return path
+    abs_path = os.path.abspath(path)
+    if abs_path.startswith('\\\\?\\'):
+        return abs_path
+    if abs_path.startswith('\\\\'):
+        return '\\\\?\\UNC\\' + abs_path[2:]
+    return '\\\\?\\' + abs_path
+
+
 def has_api_connectivity(
     hostname: str,
     port: int = 443,


### PR DESCRIPTION
* Address various path separator mismatches on the client machine (0011ebd4c49fc432caa408484c25a2b6aee83009)
* Add in support for *long* paths, previously attempting to work with paths beyond 260 characters would raise exception (b695a8b24f40f3aee4dc06dac84ad963521e3087, bfab8506e3324b5db104a1709e9aa7d935b8a698)
* Replace URL-encoded backslashes sent to file API in directory uploads (0108110d4d8e1ba45cf49a537cd8c0b581bb8f72)